### PR TITLE
Add endpoint and dispatch logic for string-derived passphrases

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -2,6 +2,7 @@ const axios = require('axios');
 
 const WORD_LIST = require('./resources.json').wordList;
 const NUMBERS_PER_CODE = 3;
+const HASHWORD_LEN = 4;
 
 const getWordCodes = (numbers) => {
   const codes = [];
@@ -26,3 +27,29 @@ module.exports.getPassphrase = async (numWords) => {
   const codes = getWordCodes(randomNumbers);
   return codes.map((c) => WORD_LIST[c]).join(' ');
 };
+
+/**
+ * Obtain a numeric hash value ranging from 0 to WORD_LIST.length from a given input string.
+ * @param {string} word - the word from which the hash value is generated
+ */
+const getWordHash = (word) => {
+  var chars = Array.from(word.toLowerCase());
+  var wordValue = chars.reduce((a, c) => a + c.charCodeAt(), 0);
+  return wordValue % WORD_LIST.length;
+}
+
+/**
+ * Return a non-random passphrase derived from the provided inputString. 
+ * Each group of HASHWORD_LEN characters (plus any remainder) generate one word in the passphrase.
+ * 
+ * @param {string} inputString - the string from which the passphrase is derived
+ */
+module.exports.getPassphraseFromCodewords = (inputString) => {
+  const codeStrings = [];
+
+  for(let i = 0; i < inputString.length; i += HASHWORD_LEN) {
+    codeStrings.push(inputString.substring(i, i + HASHWORD_LEN));
+  }
+
+  return codeStrings.map((c) => WORD_LIST[getWordHash(c)]).join(' ');
+}

--- a/server.js
+++ b/server.js
@@ -1,13 +1,18 @@
 const express = require('express');
 const path = require('path');
 
-const { getPassphrase } = require('./lib');
+const { getPassphrase, getCodedPassphrase } = require('./lib');
 
 const app = express();
 
-app.get('/generate/:numWords', async (req, res) => {
+app.get('/generate/:phr_sel', async (req, res) => {
   try {
-    const passphrase = await getPassphrase(req.params.numWords);
+    if(isNaN(req.params.phr_sel)) {
+      const passphrase = getCodedPassphrase(req.params.phr_sel);
+    }
+    else {
+      const passphrase = await getPassphrase(req.params.phr_sel);
+    }
     res.json({ success: true, passphrase });
   } catch (error) {
     res.status(500).send('Server Error');


### PR DESCRIPTION
This allows the backend to accept a string as input, and provide a deterministic response. A user could input a "codeword" and receive a non-random passphrase in return.

The front end is not yet able to accommodate this feature.

Note: needs testing.